### PR TITLE
Implement test mock user so it works without opening up security

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'edu.ksu.canvas:canvas-api:2.0.0'
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 task cleanStatic(type: Delete) {

--- a/src/main/java/com/ams/restapi/authentication/SecurityConfig.java
+++ b/src/main/java/com/ams/restapi/authentication/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                 auth.requestMatchers("/admin/**").hasAuthority("ROLE_ADMIN");
                 auth.requestMatchers("/sections").hasAnyAuthority("ROLE_ADMIN", "ROLE_INSTRUCTOR");
                 auth.requestMatchers(HttpMethod.POST, "/attendance").permitAll();
-                auth.requestMatchers(HttpMethod.GET, "/attendance").permitAll(); // TODO: temporary to allow for testing, REMOVE LATER
+                auth.requestMatchers(HttpMethod.GET, "/attendance").hasAnyAuthority("ROLE_ADMIN", "ROLE_INSTRUCTOR");
                 auth.requestMatchers(HttpMethod.POST, "/readers").permitAll();
                 auth.requestMatchers(HttpMethod.GET, "/readers").hasAnyAuthority("ROLE_ADMIN", "ROLE_INSTRUCTOR");
                 auth.requestMatchers(HttpMethod.PUT, "/readers").hasAnyAuthority("ROLE_ADMIN", "ROLE_INSTRUCTOR");

--- a/src/test/java/com/ams/restapi/attendance/AttendanceControllerTests.java
+++ b/src/test/java/com/ams/restapi/attendance/AttendanceControllerTests.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.security.test.context.support.WithMockUser;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -24,7 +25,9 @@ public class AttendanceControllerTests {
         assertNotNull(controller);
     }
 
-    @Test void shouldReturnCorrectPageSize() throws Exception {
+    @Test
+    @WithMockUser(roles="INSTRUCTOR")
+    void shouldReturnCorrectPageSize() throws Exception {
         mockMvc.perform(get("/attendance")
                 .param("room", "COOR170")
                 .param("date", "2024-01-11")


### PR DESCRIPTION
I got `shouldReturnCorrectPageSize()` working while `auth.requestMatchers(HttpMethod.GET, "/attendance")` is not set as `permitAll()` anymore. This works by using a mock user with a role of instructor, but the [documentation](https://docs.spring.io/spring-security/reference/servlet/test/mockmvc/oauth2.html#testing-oidc-login) states: 

> [If] there’s nothing OAuth2-specific about it, [...] you will likely be able to simply use @WithMockUser and be fine.

Reading 'SecurityConfig,java', it really does seem like we are not strictly enforcing OAuth based security. Not sure what or if there is a tradeoff here, but we might want to look into changing this system for the future.